### PR TITLE
Added support to download images from multiple regions.

### DIFF
--- a/BingBackground/BingBackground/BingBackground.cs
+++ b/BingBackground/BingBackground/BingBackground.cs
@@ -1,97 +1,213 @@
-﻿using Microsoft.Win32;
-using Newtonsoft.Json;
+﻿#region
+
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using System.Xml.Serialization;
+using Microsoft.Win32;
+using Newtonsoft.Json;
 
-namespace BingBackground {
+#endregion
 
-    class BingBackground {
+namespace BingBackground
+{
+    internal class BingBackground
+    {
+        private const string imageDownloadLink = "https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1&mkt={0}";
+        private const int SW_HIDE = 0;
 
-        private static void Main(string[] args) {
-            string urlBase = GetBackgroundUrlBase();
-            Image background = DownloadBackground(urlBase + GetResolutionExtension(urlBase));
-            SaveBackground(background);
-            SetBackground(GetPosition());
-        }
+        private static void Main()
+        {
+            Settings settings;
+            using (FileStream fileStream = new FileStream(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Settings.xml"), FileMode.Open))
+            {
+                settings = (Settings)new XmlSerializer(typeof(Settings)).Deserialize(fileStream);
+            }
 
-        private static dynamic DownloadJson() {
-            using (WebClient webClient = new WebClient()) {
-                Console.WriteLine("Downloading JSON...");
-                string jsonString = webClient.DownloadString("https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1&mkt=en-US");
-                return JsonConvert.DeserializeObject<dynamic>(jsonString);
+            if (settings.HideWindow)
+            {
+                ShowWindow(GetConsoleWindow(), SW_HIDE);
+            }
+
+            HashSet<string> images = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            HashSet<string> stringSet = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+            foreach (Market market in settings.Markets)
+            {
+                try
+                {
+                    string backgroundUrlBase = GetBackgroundUrlBase(market);
+                    string imageName = Path.GetFileName(backgroundUrlBase).Split(new[] { '_' }, StringSplitOptions.RemoveEmptyEntries)[0];
+
+                    if (!stringSet.Contains(imageName))
+                    {
+                        stringSet.Add(imageName);
+                        string imageUrl = backgroundUrlBase + GetResolutionExtension(backgroundUrlBase);
+                        try
+                        {
+                            Image background = DownloadBackground(imageUrl);
+                            string str = SaveBackground(imageName, background);
+                            images.Add(str);
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine("Failed to download file: {0} because of error: {1}.", imageUrl, ex.Message);
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("Skipped downloading file as it was already downloaded previously.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Failed to download image from market {0} because of error: {1}.", market.MarketName, ex.Message);
+                }
+
+                if (settings.DownloadImageFromFirstMarketOnly)
+                {
+                    break;
+                }
+            }
+
+            if (settings.DownloadImageFromFirstMarketOnly && images.Count > 0)
+            {
+                SetBackground(images.First(), PicturePosition.Stretch);
             }
         }
 
-        private static string GetBackgroundUrlBase() {
-            dynamic jsonObject = DownloadJson();
-            return "https://www.bing.com" + jsonObject.images[0].urlbase;
+        private static object DownloadJson(Market market)
+        {
+            using (WebClient webClient = new WebClient())
+            {
+                Console.WriteLine("Downloading JSON for {0}...", market.MarketName);
+                return JsonConvert.DeserializeObject<object>(webClient.DownloadString(string.Format(CultureInfo.InvariantCulture, imageDownloadLink, market.MarketId)));
+            }
         }
 
-        private static string GetBackgroundTitle() {
-            dynamic jsonObject = DownloadJson();
-            string copyrightText = jsonObject.images[0].copyright;
-            return copyrightText.Substring(0, copyrightText.IndexOf(" ("));
+        private static string GetBackgroundUrlBase(Market market)
+        {
+            dynamic obj1 = DownloadJson(market);
+            return "https://www.bing.com" + obj1.images[0].urlbase;
         }
 
-        private static bool WebsiteExists(string url) {
-            try {
-                WebRequest request = WebRequest.Create(url);
-                request.Method = "HEAD";
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                return response.StatusCode == HttpStatusCode.OK;
-            } catch {
+        private static bool WebsiteExists(string url)
+        {
+            try
+            {
+                WebRequest webRequest = WebRequest.Create(url);
+                webRequest.Method = "HEAD";
+                using (var webResponse = (HttpWebResponse)webRequest.GetResponse())
+                {
+                    return webResponse.StatusCode == HttpStatusCode.OK;
+                }
+            }
+            catch
+            {
                 return false;
             }
         }
 
-        private static string GetResolutionExtension(string url) {
+        private static string GetResolutionExtension(string url)
+        {
             Rectangle resolution = Screen.PrimaryScreen.Bounds;
             string widthByHeight = resolution.Width + "x" + resolution.Height;
             string potentialExtension = "_" + widthByHeight + ".jpg";
-            if (WebsiteExists(url + potentialExtension)) {
+            if (WebsiteExists(url + potentialExtension))
+            {
                 Console.WriteLine("Background for " + widthByHeight + " found.");
                 return potentialExtension;
-            } else {
+            }
+            else
+            {
                 Console.WriteLine("No background for " + widthByHeight + " was found.");
                 Console.WriteLine("Using 1920x1080 instead.");
                 return "_1920x1080.jpg";
             }
         }
 
-        private static void SetProxy() {
-            string proxyUrl = Properties.Settings.Default.Proxy;
-            if (proxyUrl.Length > 0) {
-                var webProxy = new WebProxy(proxyUrl, true);
-                webProxy.Credentials = CredentialCache.DefaultCredentials;
-                WebRequest.DefaultWebProxy = webProxy;
+        private static Image DownloadBackground(string url)
+        {
+            Console.WriteLine("Downloading background {0}...", url);
+
+            WebRequest request = WebRequest.Create(url);
+
+            using (WebResponse response = request.GetResponse())
+            {
+                using (var stream = response.GetResponseStream())
+                {
+                    return Image.FromStream(stream);
+                }
             }
         }
 
-        private static Image DownloadBackground(string url) {
-            Console.WriteLine("Downloading background...");
-            SetProxy();
-            WebRequest request = WebRequest.Create(url);
-            WebResponse reponse = request.GetResponse();
-            Stream stream = reponse.GetResponseStream();
-            return Image.FromStream(stream);
+        private static string GetBackgroundImagePath(string imageName)
+        {
+            string str = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures), "Bing Backgrounds", DateTime.Now.Year.ToString());
+            Directory.CreateDirectory(str);
+            return Path.Combine(str, imageName + ".png");
         }
 
-        private static string GetBackgroundImagePath() {
-            string directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures), "Bing Backgrounds", DateTime.Now.Year.ToString());
-            Directory.CreateDirectory(directory);
-            return Path.Combine(directory, DateTime.Now.ToString("M-d-yyyy") + ".bmp");
-        }
-
-        private static void SaveBackground(Image background) {
+        private static string SaveBackground(string imageName, Image background)
+        {
             Console.WriteLine("Saving background...");
-            background.Save(GetBackgroundImagePath(), System.Drawing.Imaging.ImageFormat.Bmp);
+            string backgroundImagePath = GetBackgroundImagePath(imageName);
+            background.Save(backgroundImagePath, ImageFormat.Png);
+            return backgroundImagePath;
         }
 
-        private enum PicturePosition {
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetConsoleWindow();
+
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+        private static void SetBackground(string image, PicturePosition style)
+        {
+            Console.WriteLine("Setting background...");
+            using (RegistryKey registryKey = Registry.CurrentUser.OpenSubKey(Path.Combine("Control Panel", "Desktop"), true))
+            {
+                switch (style)
+                {
+                    case PicturePosition.Tile:
+                        registryKey.SetValue("PicturePosition", "0");
+                        registryKey.SetValue("TileWallpaper", "1");
+                        break;
+                    case PicturePosition.Center:
+                        registryKey.SetValue("PicturePosition", "0");
+                        registryKey.SetValue("TileWallpaper", "0");
+                        break;
+                    case PicturePosition.Stretch:
+                        registryKey.SetValue("PicturePosition", "2");
+                        registryKey.SetValue("TileWallpaper", "0");
+                        break;
+                    case PicturePosition.Fit:
+                        registryKey.SetValue("PicturePosition", "6");
+                        registryKey.SetValue("TileWallpaper", "0");
+                        break;
+                    case PicturePosition.Fill:
+                        registryKey.SetValue("PicturePosition", "10");
+                        registryKey.SetValue("TileWallpaper", "0");
+                        break;
+                }
+            }
+
+            const int SetDesktopBackground = 20;
+            const int UpdateIniFile = 1;
+            const int SendWindowsIniChange = 2;
+            NativeMethods.SystemParametersInfo(SetDesktopBackground, 0, image, UpdateIniFile | SendWindowsIniChange);
+        }
+
+        private enum PicturePosition
+        {
             Tile,
             Center,
             Stretch,
@@ -99,65 +215,10 @@ namespace BingBackground {
             Fill
         }
 
-        private static PicturePosition GetPosition() {
-            PicturePosition position = PicturePosition.Fit;
-            switch (Properties.Settings.Default.Position) {
-                case "Tile":
-                    position = PicturePosition.Tile;
-                    break;
-                case "Center":
-                    position = PicturePosition.Center;
-                    break;
-                case "Stretch":
-                    position = PicturePosition.Stretch;
-                    break;
-                case "Fit":
-                    position = PicturePosition.Fit;
-                    break;
-                case "Fill":
-                    position = PicturePosition.Fill;
-                    break;
-            }
-            return position;
-        }
-
-        internal sealed class NativeMethods {
+        internal sealed class NativeMethods
+        {
             [DllImport("user32.dll", CharSet = CharSet.Auto)]
             internal static extern int SystemParametersInfo(int uAction, int uParam, string lpvParam, int fuWinIni);
         }
-
-        private static void SetBackground(PicturePosition style) {
-            Console.WriteLine("Setting background...");
-            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(Path.Combine("Control Panel", "Desktop"), true)) {
-                switch (style) {
-                    case PicturePosition.Tile:
-                        key.SetValue("PicturePosition", "0");
-                        key.SetValue("TileWallpaper", "1");
-                        break;
-                    case PicturePosition.Center:
-                        key.SetValue("PicturePosition", "0");
-                        key.SetValue("TileWallpaper", "0");
-                        break;
-                    case PicturePosition.Stretch:
-                        key.SetValue("PicturePosition", "2");
-                        key.SetValue("TileWallpaper", "0");
-                        break;
-                    case PicturePosition.Fit:
-                        key.SetValue("PicturePosition", "6");
-                        key.SetValue("TileWallpaper", "0");
-                        break;
-                    case PicturePosition.Fill:
-                        key.SetValue("PicturePosition", "10");
-                        key.SetValue("TileWallpaper", "0");
-                        break;
-                }
-            }
-            const int SetDesktopBackground = 20;
-            const int UpdateIniFile = 1;
-            const int SendWindowsIniChange = 2;
-            NativeMethods.SystemParametersInfo(SetDesktopBackground, 0, GetBackgroundImagePath(), UpdateIniFile | SendWindowsIniChange);
-        }
-
     }
-
 }

--- a/BingBackground/BingBackground/Market.cs
+++ b/BingBackground/BingBackground/Market.cs
@@ -1,0 +1,23 @@
+﻿using System.Xml.Serialization;
+
+namespace BingBackground
+{
+  public class Market
+  {
+    [XmlAttribute]
+    public string MarketId { get; set; }
+
+    [XmlAttribute]
+    public string MarketName { get; set; }
+
+    public Market()
+    {
+    }
+
+    public Market(string marketId, string marketName)
+    {
+      this.MarketId = marketId;
+      this.MarketName = marketName;
+    }
+  }
+}

--- a/BingBackground/BingBackground/Settings.cs
+++ b/BingBackground/BingBackground/Settings.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace BingBackground
+{
+  public class Settings
+  {
+    public bool HideWindow { get; set; }
+
+    public bool DownloadImageFromFirstMarketOnly { get; set; }
+
+    public List<Market> Markets { get; set; }
+
+    public Settings()
+    {
+      this.HideWindow = false;
+      this.DownloadImageFromFirstMarketOnly = true;
+      this.Markets = new List<Market>();
+    }
+  }
+}

--- a/BingBackground/BingBackground/Settings.xml
+++ b/BingBackground/BingBackground/Settings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<Settings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <HideWindow>true</HideWindow>
+  <DownloadImageFromFirstMarketOnly>true</DownloadImageFromFirstMarketOnly>
+  <Markets>
+    <Market MarketId="en-IN" MarketName="India" />
+    <Market MarketId="es-AR" MarketName="Argentina" />
+    <Market MarketId="en-AU" MarketName="Australia" />
+    <Market MarketId="de-AT" MarketName="Austria" />
+    <Market MarketId="nl-BE" MarketName="Belgium - Dutch" />
+    <Market MarketId="fr-BE" MarketName="Belgium - French" />
+    <Market MarketId="pt-BR" MarketName="Brazil" />
+    <Market MarketId="en-CA" MarketName="Canada - English" />
+    <Market MarketId="fr-CA" MarketName="Canada - French" />
+    <Market MarketId="fr-FR" MarketName="France" />
+    <Market MarketId="de-DE" MarketName="Germany" />
+    <Market MarketId="zh-HK" MarketName="Hong Kong S.A.R." />
+    <Market MarketId="en-ID" MarketName="Indonesia" />
+    <Market MarketId="it-IT" MarketName="Italy" />
+    <Market MarketId="ja-JP" MarketName="Japan" />
+    <Market MarketId="ko-KR" MarketName="Korea" />
+    <Market MarketId="en-MY" MarketName="Malaysia" />
+    <Market MarketId="es-MX" MarketName="Mexico" />
+    <Market MarketId="nl-NL" MarketName="Netherlands" />
+    <Market MarketId="nb-NO" MarketName="Norway" />
+    <Market MarketId="zh-CN" MarketName="People's Republic of China" />
+    <Market MarketId="pl-PL" MarketName="Poland" />
+    <Market MarketId="ru-RU" MarketName="Russia" />
+    <Market MarketId="ar-SA" MarketName="Saudi Arabia" />
+    <Market MarketId="en-ZA" MarketName="South Africa" />
+    <Market MarketId="es-ES" MarketName="Spain" />
+    <Market MarketId="sv-SE" MarketName="Sweden" />
+    <Market MarketId="fr-CH" MarketName="Switzerland - French" />
+    <Market MarketId="de-CH" MarketName="Switzerland - German" />
+    <Market MarketId="zh-TW" MarketName="Taiwan" />
+    <Market MarketId="tr-TR" MarketName="Turkey" />
+    <Market MarketId="en-GB" MarketName="United Kingdom" />
+    <Market MarketId="en-US" MarketName="United States - English" />
+    <Market MarketId="es-US" MarketName="United States - Spanish" />
+  </Markets>
+</Settings>


### PR DESCRIPTION
1. If downloading from multiple regions, the code now does not force the wallpaper. Instead it is expected that user sets the wallpaper to be a slide show pointing to Bing Wallpaper\Year folder
2. Added support for hiding the console window. I use it when I run it as a schedule task.
3. This code does not have the change that sets the proxy since .NET automatically uses the system proxy by default  in my testing
4. Fixed improper disposing of WebClients that caused a TimeoutException when downloading multiple images.
